### PR TITLE
Fixed file input value error by preventing formatting on file

### DIFF
--- a/src/components/Input/index.jsx
+++ b/src/components/Input/index.jsx
@@ -67,6 +67,12 @@ const Input = forwardRef(
     const isMaxLengthPresent = !!maxLength || maxLength === 0;
 
     const handleChange = e => {
+      if (type === "file") {
+        onChange(e);
+
+        return;
+      }
+
       let formattedValue = formatWithRejectCharsRegex(
         e.target.value,
         rejectCharsRegex
@@ -79,6 +85,12 @@ const Input = forwardRef(
     };
 
     const handleOnBlur = e => {
+      if (type === "file") {
+        onBlur?.(e);
+
+        return;
+      }
+
       const trimmedValue = getTrimmedValue(value, disableTrimOnBlur);
       const formattedValue = formatWithPrecision(trimmedValue, precision);
 

--- a/tests/Input.test.jsx
+++ b/tests/Input.test.jsx
@@ -225,4 +225,17 @@ describe("Input", () => {
     expect(blurSpy).not.toHaveBeenCalled();
     blurSpy.mockRestore();
   });
+
+  it("should handle file inputs without formatting errors", async () => {
+    const onChange = jest.fn();
+    const { getByLabelText } = render(
+      <Input {...{ onChange }} id="file-input" label="File Input" type="file" />
+    );
+    const fileInput = getByLabelText("File Input");
+
+    const file = new File(["test content"], "test.txt", { type: "text/plain" });
+    await userEvent.upload(fileInput, file);
+
+    expect(onChange).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
- Fixes #2527 

**Description**

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added proper `data-cy` and `data-testid` attributes.
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
