### PR TITLE
Add periods to NoData headings

### DIFF
--- a/stories/Components/NoData.stories.jsx
+++ b/stories/Components/NoData.stories.jsx
@@ -20,7 +20,7 @@ const Template = args => (
     <NoData
       {...args}
       primaryButtonProps={{ label: "Add new ticket" }}
-      title="There are no tickets to show"
+      title="There are no tickets to show."
     />
   </div>
 );
@@ -33,7 +33,7 @@ const WithDescription = args => (
       {...args}
       description="You can try adding a new ticket."
       primaryButtonProps={{ label: "Add new ticket" }}
-      title="There are no tickets to show"
+      title="There are no tickets to show."
     />
   </div>
 );
@@ -48,7 +48,7 @@ const WithSecondaryButton = args => (
       description="You can try adding a new suite or importing test cases."
       primaryButtonProps={{ label: "Add new suite" }}
       secondaryButtonProps={{ label: "Import Test Cases" }}
-      title="There are no suites to show"
+      title="There are no suites to show."
     />
   </div>
 );
@@ -61,7 +61,7 @@ const WithHelpText = args => (
       className="col-span-1"
       {...args}
       primaryButtonProps={{ label: "Add new form" }}
-      title="There are no forms to show"
+      title="There are no forms to show."
       helpText={
         <>
           Learn about{" "}
@@ -79,7 +79,7 @@ const WithHelpText = args => (
       className="col-span-1"
       {...args}
       primaryButtonProps={{ label: "Add new discount code" }}
-      title="There are no discount codes to show"
+      title="There are no discount codes to show."
       helpText={
         <>
           Learn about{" "}
@@ -97,7 +97,7 @@ const WithHelpText = args => (
       className="col-span-1"
       {...args}
       primaryButtonProps={{ label: "Add new invoices" }}
-      title="There are no invoices to show"
+      title="There are no invoices to show."
       helpText={
         <>
           Learn about{" "}
@@ -115,7 +115,7 @@ const WithHelpText = args => (
       className="col-span-1"
       {...args}
       primaryButtonProps={{ label: "Add new custom domain" }}
-      title="There are no custom domains to show"
+      title="There are no custom domains to show."
       helpText={
         <>
           Learn about{" "}
@@ -178,7 +178,7 @@ const WithCustomImageFromURL = args => (
       {...args}
       image="https://cdn-icons-png.flaticon.com/512/15/15457.png"
       primaryButtonProps={{ label: "Add new ticket" }}
-      title="There are no tickets to show"
+      title="There are no tickets to show."
     />
   </div>
 );
@@ -192,7 +192,7 @@ const CSSCustomization = args => (
       className="neetix-nodata"
       image="https://cdn-icons-png.flaticon.com/512/15/15457.png"
       primaryButtonProps={{ label: "Add new ticket" }}
-      title="There are no tickets to show"
+      title="There are no tickets to show."
     />
   </div>
 );

--- a/tests/NoData.test.jsx
+++ b/tests/NoData.test.jsx
@@ -10,17 +10,17 @@ describe("Typography", () => {
     const { getByText } = render(
       <NoData
         primaryButtonProps={{ label: "Add new ticket" }}
-        title="There are no tickets to show"
+        title="There are no tickets to show."
       />
     );
-    expect(getByText("There are no tickets to show")).toBeInTheDocument();
+    expect(getByText("There are no tickets to show.")).toBeInTheDocument();
   });
 
   it("should display primary and secondary button tooltips when button is disabled and showTooltipWhenButtonDisabled is true", async () => {
     const { getByTestId } = render(
       <NoData
         showTooltipWhenButtonDisabled
-        title="There are no tickets to show"
+        title="There are no tickets to show."
         primaryButtonProps={{
           label: "Add new ticket",
           tooltipProps: { content: "Primary tooltip" },
@@ -47,7 +47,7 @@ describe("Typography", () => {
     const { getByTestId } = render(
       <NoData
         showTooltipWhenButtonDisabled={false}
-        title="There are no tickets to show"
+        title="There are no tickets to show."
         primaryButtonProps={{
           label: "Add new ticket",
           tooltipProps: { content: "Primary tooltip" },
@@ -75,7 +75,7 @@ describe("Typography", () => {
   it("should display primary and secondary button tooltips when button is not disabled", async () => {
     const { getByTestId } = render(
       <NoData
-        title="There are no tickets to show"
+        title="There are no tickets to show."
         primaryButtonProps={{
           label: "Add new ticket",
           tooltipProps: { content: "Primary tooltip" },


### PR DESCRIPTION
# Add periods to NoData headings

Ref: https://github.com/neetozone/neeto-engineering-web/issues/1411

## Summary
Updated NoData component stories and tests to add periods to full-sentence headings, aligning with UI/UX guidelines that complete sentences should end with proper punctuation. This affects story examples used for documentation and the corresponding test assertions.

**Changes made:**
- Added periods to NoData heading titles in story examples (e.g., "There are no tickets to show" → "There are no tickets to show.")
- Updated test assertion to expect the heading with a period
- Applied changes consistently across all story variants (WithDescription, WithSecondaryButton, WithHelpText, etc.)

## Review & Testing Checklist for Human
- [ ] **Verify test assertions match component behavior** - Run the tests and ensure the `getByText("There are no tickets to show.")` assertion actually finds the rendered text
- [ ] **Check story examples render correctly** - Open Storybook and verify all NoData story examples display properly with periods
- [ ] **Test component in isolation** - Create a simple test case to verify the NoData component renders titles with periods as expected
- [ ] **Verify no regressions** - Check that existing NoData usage in other applications won't be broken by these changes

---

### Diagram
```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    Stories["stories/Components/NoData.stories.jsx"]:::major-edit
    Tests["tests/NoData.test.jsx"]:::major-edit
    Component["src/components/NoData/index.jsx"]:::context
    
    Stories -->|"uses"| Component
    Tests -->|"tests"| Component
    
    Stories -->|"updated headings<br/>with periods"| Examples["Story Examples<br/>(Template, WithDescription, etc.)"]
    Tests -->|"updated assertion<br/>to expect period"| Assertion["getByText expectation"]
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes
- This is part of a broader initiative to standardize NoData headings across all neeto products
- Since neeto-ui is a shared library, these changes will affect all consuming applications
- The changes are purely cosmetic (adding periods) but maintain the same semantic meaning
- Pre-commit hooks (prettier, eslint) passed successfully during commit

**Session Info:**
- Link to Devin run: https://app.devin.ai/sessions/618504fc01a84d8ebf3354203a550afe
- Requested by: @pratiksau
