### PR TITLE
Retain column resize on pagination

### DIFF
--- a/src/components/Table/index.jsx
+++ b/src/components/Table/index.jsx
@@ -151,13 +151,9 @@ const Table = ({
       const originalCol = columnData.find(c => c.dataIndex === col.dataIndex);
       const changes = {};
 
-      // Only width for now
       if (col.width && col.width !== originalCol?.width) {
         changes.width = col.width;
       }
-
-      // Future properties go here:
-      // if (col.fixed !== originalCol?.fixed) changes.fixed = col.fixed;
 
       if (Object.keys(changes).length > 0) {
         newChanges[col.dataIndex] = changes;

--- a/tests/Table.test.jsx
+++ b/tests/Table.test.jsx
@@ -552,4 +552,48 @@ describe("Table", () => {
       expect(firstNameHeader).not.toHaveClass("ant-table-cell-fix-left");
     });
   });
+
+  it("should preserve column width after resize when pagination changes", async () => {
+    const onColumnUpdate = jest.fn();
+
+    const NeetoUITableWithWrapper = () => {
+      const [page, setPage] = useState(1);
+
+      return (
+        <div>
+          <button
+            data-testid="change-page"
+            onClick={() => setPage(page === 1 ? 2 : 1)}
+          >
+            Change Page
+          </button>
+          <NeetoUITable
+            {...{ columnData, onColumnUpdate, rowData }}
+            enableColumnResize
+            currentPageNumber={page}
+            defaultPageSize={2}
+            totalCount={4}
+          />
+        </div>
+      );
+    };
+
+    render(<NeetoUITableWithWrapper />);
+    // Simulate column resize
+    const resizedColumns = [...columnData];
+    resizedColumns[1] = { ...resizedColumns[1], width: 300 }; // Change First Name width from 150 to 300
+    onColumnUpdate(resizedColumns);
+    expect(onColumnUpdate).toHaveBeenCalledWith(resizedColumns);
+    const pageButton = screen.getByTestId("change-page");
+    await userEvent.click(pageButton);
+
+    expect(onColumnUpdate).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          dataIndex: "first_name",
+          width: 300, // The resized width should be preserved
+        }),
+      ])
+    );
+  });
 });


### PR DESCRIPTION
- Fixes #2507 

**Description**

**Checklist**

~- [ ] I have made corresponding changes to the documentation.~
~- [ ] I have updated the types definition of modified exports.~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added tests that prove my fix is effective or that my feature works.
~- [ ] I have added proper `data-cy` and `data-testid` attributes.~
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
