### PR TITLE
Added data-cy label

### DIFF
--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -4,9 +4,10 @@ import classnames from "classnames";
 import PropTypes from "prop-types";
 import { Link } from "react-router-dom";
 
+import { hyphenize } from "utils";
+
 import Spinner from "./Spinner";
 import Tooltip from "./Tooltip";
-import { hyphenize } from "utils";
 
 const BUTTON_STYLES = {
   primary: "primary",
@@ -98,7 +99,12 @@ const Button = React.forwardRef(
           {...{ disabled, ref, ...elementSpecificProps, ...otherProps }}
         >
           {renderLabel && (
-            <span className="neeto-ui-btn__label" data-cy={hyphenize(renderLabel)}>{renderLabel}</span>
+            <span
+              className="neeto-ui-btn__label"
+              data-cy={hyphenize(renderLabel)}
+            >
+              {renderLabel}
+            </span>
           )}
           {icon && (
             <Icon

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -6,6 +6,7 @@ import { Link } from "react-router-dom";
 
 import Spinner from "./Spinner";
 import Tooltip from "./Tooltip";
+import { hyphenize } from "utils";
 
 const BUTTON_STYLES = {
   primary: "primary",
@@ -97,7 +98,7 @@ const Button = React.forwardRef(
           {...{ disabled, ref, ...elementSpecificProps, ...otherProps }}
         >
           {renderLabel && (
-            <span className="neeto-ui-btn__label">{renderLabel}</span>
+            <span className="neeto-ui-btn__label" data-cy={hyphenize(renderLabel)}>{renderLabel}</span>
           )}
           {icon && (
             <Icon


### PR DESCRIPTION
- Fixes https://github.com/neetozone/neeto-auth-playwright/issues/8

**Description**
Added data-cy label for `Open Neetocal`

**Checklist**

- ~[ ] I have made corresponding changes to the documentation.~
- ~[ ] I have updated the types definition of modified exports.~
- [x] I have verified the functionality in some of the neeto web-apps.
- ~[ ] I have added tests that prove my fix is effective or that my feature works.~
- ~[ ] I have added proper `data-cy` and `data-testid` attributes.~
- ~[ ] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).~

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
