### PR TITLE
Wordsmith validation message

### DIFF
--- a/src/components/MultiEmailInput/index.jsx
+++ b/src/components/MultiEmailInput/index.jsx
@@ -18,6 +18,7 @@ import {
   renderValidEmails,
   renderDefaultText,
   getValidEmailsCount,
+  renderDuplicateEmailsWarningMessage,
 } from "./utils";
 
 import Label from "../Label";
@@ -237,8 +238,7 @@ const MultiEmailInput = forwardRef(
             className="neeto-ui-input__error"
             data-cy={`${hyphenize(label)}-duplicate-emails-warning`}
           >
-            Duplicate emails detected and removed (matched case-insensitively):{" "}
-            {duplicateEmails.join(", ")}
+            {renderDuplicateEmailsWarningMessage(duplicateEmails)}
           </p>
         )}
       </div>

--- a/src/components/MultiEmailInput/utils.js
+++ b/src/components/MultiEmailInput/utils.js
@@ -57,3 +57,11 @@ export const renderValidEmails = values =>
 export const getValidEmailsCount = values => renderValidEmails(values).length;
 
 export const renderDefaultText = count => (count === 1 ? "email" : "emails");
+
+export const renderDuplicateEmailsWarningMessage = duplicateEmails => {
+  const count = duplicateEmails.length;
+
+  return `Removed ${count} duplicate ${renderDefaultText(
+    count
+  )} from the list: ${duplicateEmails.join(", ")}`;
+};

--- a/tests/MultiEmailInput.test.jsx
+++ b/tests/MultiEmailInput.test.jsx
@@ -274,7 +274,7 @@ describe("MultiEmailInput", () => {
 
     expect(
       screen.getByText(
-        "Duplicate emails detected and removed (matched case-insensitively): test@Example.com"
+        "Removed 1 duplicate email from the list: test@Example.com"
       )
     ).toBeInTheDocument();
   });


### PR DESCRIPTION
- Fixes #2549 

**Description**
- Changed: Formulated a user-friendly version of the duplicate email validation message

**Checklist**

- [ ] ~I have made corresponding changes to the documentation.~
- [ ] ~I have updated the types definition of modified exports.~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] ~I have added proper `data-cy` and `data-testid` attributes.~
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
