### PR TITLE
Prevents duplicate requests in Alert due to transition delay

### DIFF
--- a/src/components/Alert.jsx
+++ b/src/components/Alert.jsx
@@ -77,7 +77,7 @@ const Alert = ({
         )}
         <Button
           data-cy="alert-submit-button"
-          disabled={isSubmitting}
+          disabled={isSubmitting || !isOpen}
           label={submitButtonLabel}
           loading={isSubmitting}
           ref={submitButtonRef}

--- a/tests/Alert.test.jsx
+++ b/tests/Alert.test.jsx
@@ -139,30 +139,14 @@ describe("Alert", () => {
     expect(queryByText("Cancel")).not.toBeInTheDocument();
   });
 
-  it("should not call onSubmit while alert is closing (transition delay)", async () => {
-    const onSubmit = jest.fn();
-
-    const { rerender, getByText } = render(
-      <Alert {...{ onSubmit }} isOpen submitButtonLabel="Submit" />
-    );
-
-    await userEvent.click(getByText("Submit"));
-
-    rerender(
-      <Alert {...{ onSubmit }} isOpen={false} submitButtonLabel="Submit" />
-    );
-
-    await userEvent.click(getByText("Submit"));
-    expect(onSubmit).toHaveBeenCalledTimes(1);
-  });
-
   it("should not call onSubmit when isSubmitting is true", async () => {
     const onSubmit = jest.fn();
-    const { getByText } = render(
+    const { getByRole } = render(
       <Alert {...{ onSubmit }} isOpen isSubmitting submitButtonLabel="Submit" />
     );
 
-    const submitButton = getByText("Submit");
+    const submitButton = getByRole("button", { name: "Submit" });
+
     expect(submitButton).toBeDisabled();
     await userEvent.click(submitButton);
     expect(onSubmit).not.toHaveBeenCalled();

--- a/tests/Alert.test.jsx
+++ b/tests/Alert.test.jsx
@@ -138,4 +138,33 @@ describe("Alert", () => {
     );
     expect(queryByText("Cancel")).not.toBeInTheDocument();
   });
+
+  it("should not call onSubmit while alert is closing (transition delay)", async () => {
+    const onSubmit = jest.fn();
+
+    const { rerender, getByText } = render(
+      <Alert {...{ onSubmit }} isOpen submitButtonLabel="Submit" />
+    );
+
+    await userEvent.click(getByText("Submit"));
+
+    rerender(
+      <Alert {...{ onSubmit }} isOpen={false} submitButtonLabel="Submit" />
+    );
+
+    await userEvent.click(getByText("Submit"));
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not call onSubmit when isSubmitting is true", async () => {
+    const onSubmit = jest.fn();
+    const { getByText } = render(
+      <Alert {...{ onSubmit }} isOpen isSubmitting submitButtonLabel="Submit" />
+    );
+
+    const submitButton = getByText("Submit");
+    expect(submitButton).toBeDisabled();
+    await userEvent.click(submitButton);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
- Fixes #2553

**Description**
 - Prevents duplicate requests in Alert due to transition delay

**Checklist**

~~- [ ] I have made corresponding changes to the documentation.~~
~~- [ ] I have updated the types definition of modified exports.~~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added tests that prove my fix is effective or that my feature works.
~~- [ ] I have added proper `data-cy` and `data-testid` attributes.~~
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
