### PR TITLE
Added `/dist` as one of the valid exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,12 @@
     "./translations/*": {
       "import": "./src/translations/*.json",
       "require": "./src/translations/*.json"
+    },
+    "./dist": {
+      "import": "./dist/index.js",
+      "require": "./dist/cjs/index.js",
+      "style": "./dist/index.css",
+      "types": "./index.d.ts"
     }
   },
   "devDependencies": {


### PR DESCRIPTION
- Fixes #2567 

**Description**

- This change is necessary to let ESBuild understand that `@import(@bigbinary/neetoui/dist)` in a CSS file needs to import the stylesheet.

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added proper `data-cy` and `data-testid` attributes.
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
