### PR TITLE
Implemented calendar change handler in DatePicker component

### DIFF
--- a/src/components/DatePicker/index.jsx
+++ b/src/components/DatePicker/index.jsx
@@ -105,13 +105,12 @@ const DatePicker = forwardRef(
 
     const handleOnCalendarChange = date => {
       if (!date) return;
-
       const allowed = getAllowedValue(getTimezoneAppliedDateTime(date));
       setValue(allowed);
     };
 
     const handleOnOpenChange = open => {
-      if (!open && value) {
+      if (!open && value !== inputValue) {
         onChange(value, formattedString(value, dateFormat));
       }
 

--- a/src/components/DatePicker/index.jsx
+++ b/src/components/DatePicker/index.jsx
@@ -103,7 +103,18 @@ const DatePicker = forwardRef(
       return onChange(allowed, formattedString(allowed, dateFormat));
     };
 
+    const handleOnCalendarChange = date => {
+      if (!date) return;
+
+      const allowed = getAllowedValue(getTimezoneAppliedDateTime(date));
+      setValue(allowed);
+    };
+
     const handleOnOpenChange = open => {
+      if (!open && value) {
+        onChange(value, formattedString(value, dateFormat));
+      }
+
       isDatePickerOpen.current = open;
       onOpenChange?.(open);
     };
@@ -153,6 +164,7 @@ const DatePicker = forwardRef(
               dropdownClassName, // Will be removed in the next major version
               popupClassName,
             ])}
+            onCalendarChange={handleOnCalendarChange}
             onChange={handleOnChange}
             onKeyDown={handleOnKeyDown}
             onOpenChange={handleOnOpenChange}


### PR DESCRIPTION
- Fixes #2566 

**Description**

Saves date and time automatically on clicking outside the dropdown if selected.

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added proper `data-cy` and `data-testid` attributes.
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
