### PR TITLE
Fix the opacity styling for the disabled option in the select dropdown

### DIFF
--- a/src/styles/components/_select.scss
+++ b/src/styles/components/_select.scss
@@ -54,7 +54,7 @@
   --neeto-ui-select-menu-option-focus-bg-color: rgb(var(--neeto-ui-gray-200));
 
   // Menu Option Disabled
-  --neeto-ui-select-menu-option-disabled-color: rgb(var(--neeto-ui-gray-200));
+  --neeto-ui-select-menu-option-disabled-color: rgb(var(--neeto-ui-gray-400));
 
   // Menu Option Active
   --neeto-ui-select-menu-option-acitve-bg-color: rgb(var(--neeto-ui-primary-500));


### PR DESCRIPTION
- Fixes #2590 

**Description**

- Fixed: Opacity styling for the disabled option in the select dropdown.

### Before
<img width="381" height="262" alt="Screenshot 2025-09-04 at 12 24 01 PM" src="https://github.com/user-attachments/assets/f0b67efd-60e3-4535-a388-f78a2bfc993d" />

### After
<img width="381" height="261" alt="Screenshot 2025-09-04 at 12 23 48 PM" src="https://github.com/user-attachments/assets/0a76262d-a0a3-430e-b99b-8ce2ec8a3b7a" />

@praveen-murali-ind _a

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [ ] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added proper `data-cy` and `data-testid` attributes.
- [ ] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
