### PR TITLE
Add persistUserSortPreferences prop to persist Table sorting across navigation

### DIFF
--- a/src/components/Table/hooks/useTableSort.js
+++ b/src/components/Table/hooks/useTableSort.js
@@ -1,19 +1,29 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
-import { mergeLeft } from "ramda";
+import { isPresent } from "neetocist";
+import { isNil, mergeLeft } from "ramda";
 import { useHistory } from "react-router-dom";
 
 import { useQueryParams } from "hooks";
-import { buildUrl } from "utils";
+import { buildUrl, setToLocalStorage } from "utils";
 
 import { URL_SORT_ORDERS } from "../constants";
-import { getSortInfoFromQueryParams, getSortField } from "../utils";
+import {
+  getSortInfoFromQueryParams,
+  getSortField,
+  getPersistedTableSort,
+  getSortPreferenceLocalStorageKey,
+} from "../utils";
 
-const useTableSort = () => {
+const useTableSort = ({
+  shouldPersistSort = false,
+  localStorageKeyPrefix,
+} = {}) => {
   const queryParams = useQueryParams();
   const [sortedInfo, setSortedInfo] = useState(() =>
     getSortInfoFromQueryParams(queryParams)
   );
+  const hasRestoredPersistedSort = useRef(false);
 
   useEffect(() => {
     setSortedInfo(getSortInfoFromQueryParams(queryParams));
@@ -21,12 +31,45 @@ const useTableSort = () => {
 
   const history = useHistory();
 
+  const persistSortPreference = params => {
+    if (!shouldPersistSort) return;
+
+    setToLocalStorage(getSortPreferenceLocalStorageKey(localStorageKeyPrefix), {
+      sort_by: params.sort_by ?? null,
+      order_by: params.order_by ?? null,
+    });
+  };
+
+  useEffect(() => {
+    if (hasRestoredPersistedSort.current) return;
+    hasRestoredPersistedSort.current = true;
+
+    if (!shouldPersistSort || isPresent(queryParams.sort_by)) return;
+
+    const persistedSort = getPersistedTableSort(localStorageKeyPrefix);
+    if (isNil(persistedSort?.sort_by) || isNil(persistedSort?.order_by)) return;
+
+    // Restore the persisted sort into the URL on mount; the URL remains the
+    // single source of truth afterwards.
+    history.replace(
+      buildUrl(
+        window.location.pathname,
+        mergeLeft(
+          { sort_by: persistedSort.sort_by, order_by: persistedSort.order_by },
+          queryParams
+        )
+      )
+    );
+  }, [shouldPersistSort, localStorageKeyPrefix, queryParams, history]);
+
   const handleTableChange = (pagination, sorter) => {
     const params = {
       sort_by: sorter.order ? getSortField(sorter.field) : undefined,
       order_by: URL_SORT_ORDERS[sorter.order],
       page: pagination.current,
     };
+
+    persistSortPreference(params);
 
     const pathname = window.location.pathname;
     history.push(buildUrl(pathname, mergeLeft(params, queryParams)));

--- a/src/components/Table/hooks/useTableSort.js
+++ b/src/components/Table/hooks/useTableSort.js
@@ -1,13 +1,13 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { isPresent } from "neetocist";
 import { isNil, mergeLeft } from "ramda";
 import { useHistory } from "react-router-dom";
 
 import { useQueryParams } from "hooks";
-import { buildUrl, setToLocalStorage } from "utils";
+import { buildUrl, getQueryParams, setToLocalStorage } from "utils";
 
-import { URL_SORT_ORDERS } from "../constants";
+import { TABLE_SORT_ORDERS, URL_SORT_ORDERS } from "../constants";
 import {
   getSortInfoFromQueryParams,
   getSortField,
@@ -23,7 +23,6 @@ const useTableSort = ({
   const [sortedInfo, setSortedInfo] = useState(() =>
     getSortInfoFromQueryParams(queryParams)
   );
-  const hasRestoredPersistedSort = useRef(false);
 
   useEffect(() => {
     setSortedInfo(getSortInfoFromQueryParams(queryParams));
@@ -41,13 +40,18 @@ const useTableSort = ({
   };
 
   useEffect(() => {
-    if (hasRestoredPersistedSort.current) return;
-    hasRestoredPersistedSort.current = true;
+    if (!shouldPersistSort) return;
 
-    if (!shouldPersistSort || isPresent(queryParams.sort_by)) return;
+    const currentQueryParams = getQueryParams();
+    if (isPresent(currentQueryParams.sort_by)) return;
 
     const persistedSort = getPersistedTableSort(localStorageKeyPrefix);
-    if (isNil(persistedSort?.sort_by) || isNil(persistedSort?.order_by)) return;
+    if (
+      isNil(persistedSort?.sort_by) ||
+      isNil(TABLE_SORT_ORDERS[persistedSort?.order_by])
+    ) {
+      return;
+    }
 
     // Restore the persisted sort into the URL on mount; the URL remains the
     // single source of truth afterwards.
@@ -56,11 +60,11 @@ const useTableSort = ({
         window.location.pathname,
         mergeLeft(
           { sort_by: persistedSort.sort_by, order_by: persistedSort.order_by },
-          queryParams
+          currentQueryParams
         )
       )
     );
-  }, [shouldPersistSort, localStorageKeyPrefix, queryParams, history]);
+  }, [shouldPersistSort, localStorageKeyPrefix, history]);
 
   const handleTableChange = (pagination, sorter) => {
     const params = {

--- a/src/components/Table/index.jsx
+++ b/src/components/Table/index.jsx
@@ -71,7 +71,7 @@ const Table = ({
   onMoreActionClick,
   bulkSelectAllRowsProps,
   localStorageKeyPrefix,
-  persistUserSortPreferences = false,
+  persistSort = false,
   virtual = false,
   ...otherProps
 }) => {
@@ -87,7 +87,7 @@ const Table = ({
     sortedInfo,
     setSortedInfo,
   } = useTableSort({
-    shouldPersistSort: persistUserSortPreferences && isDefaultPageChangeHandler,
+    shouldPersistSort: persistSort && isDefaultPageChangeHandler,
     localStorageKeyPrefix,
   });
 
@@ -568,7 +568,7 @@ Table.propTypes = {
   /**
    * Persists the sorting state in local storage and restores it when the table mounts without sort params in the URL. A URL with explicit sort params takes precedence over the persisted preference. Applicable only when the default page change handler is used. The storage key can be customized with `localStorageKeyPrefix`.
    */
-  persistUserSortPreferences: PropTypes.bool,
+  persistSort: PropTypes.bool,
   /**
    * Whether to use virtual scrolling (beta).
    */

--- a/src/components/Table/index.jsx
+++ b/src/components/Table/index.jsx
@@ -71,6 +71,7 @@ const Table = ({
   onMoreActionClick,
   bulkSelectAllRowsProps,
   localStorageKeyPrefix,
+  persistUserSortPreferences = false,
   virtual = false,
   ...otherProps
 }) => {
@@ -79,16 +80,19 @@ const Table = ({
   const [columns, setColumns] = useState(columnData);
   const [bulkSelectedAllRows, setBulkSelectedAllRows] = useState(false);
   const [columnChanges, setColumnChanges] = useState({});
+  const isDefaultPageChangeHandler = handlePageChange === noop;
+
   const {
     handleTableChange: handleTableSortChange,
     sortedInfo,
     setSortedInfo,
-  } = useTableSort();
+  } = useTableSort({
+    shouldPersistSort: persistUserSortPreferences && isDefaultPageChangeHandler,
+    localStorageKeyPrefix,
+  });
 
   const { setBulkSelectedAllRows: handleSetBulkSelectedAllRows } =
     bulkSelectAllRowsProps ?? {};
-
-  const isDefaultPageChangeHandler = handlePageChange === noop;
 
   const history = useHistory();
 
@@ -558,9 +562,13 @@ Table.propTypes = {
     clearSelectionButtonLabel: PropTypes.string,
   }),
   /**
-   * String to set as the prefix of the local storage key where the data is persisted, eg: fixed columns.
+   * String to set as the prefix of the local storage key where the data is persisted, eg: fixed columns, sort preference.
    */
   localStorageKeyPrefix: PropTypes.string,
+  /**
+   * Persists the sorting state in local storage and restores it when the table mounts without sort params in the URL. A URL with explicit sort params takes precedence over the persisted preference. Applicable only when the default page change handler is used. The storage key can be customized with `localStorageKeyPrefix`.
+   */
+  persistUserSortPreferences: PropTypes.bool,
   /**
    * Whether to use virtual scrolling (beta).
    */

--- a/src/components/Table/utils.js
+++ b/src/components/Table/utils.js
@@ -1,6 +1,8 @@
 import { isPresent, snakeToCamelCase, camelToSnakeCase } from "neetocist";
 import { __, all, equals, filter, includes, pipe, pluck } from "ramda";
 
+import { getFromLocalStorage } from "utils";
+
 import {
   CellContent,
   HeaderCell,
@@ -90,6 +92,19 @@ export const getFrozenColumnsLocalStorageKey = localStorageKeyPrefix => {
 
   return `NEETOUI-${prefix}-FIXED_COLUMNS`;
 };
+
+export const getSortPreferenceLocalStorageKey = localStorageKeyPrefix => {
+  const prefix = isPresent(localStorageKeyPrefix)
+    ? localStorageKeyPrefix
+    : convertLocationPathnameToId();
+
+  return `NEETOUI-${prefix}-SORT`;
+};
+
+export const getPersistedTableSort = localStorageKeyPrefix =>
+  getFromLocalStorage(
+    getSortPreferenceLocalStorageKey(localStorageKeyPrefix)
+  ) ?? null;
 
 export const getSortInfoFromQueryParams = queryParams => {
   const sortedInfo = {};

--- a/stories/Components/Table.stories.jsx
+++ b/stories/Components/Table.stories.jsx
@@ -234,7 +234,7 @@ const metadata = {
       control: "function",
       table: { type: { summary: "func" } },
     },
-    persistUserSortPreferences: {
+    persistSort: {
       description:
         "Persists the sorting state in the local storage and restores it when the Table mounts without sort params in the URL. Applicable only when the default page change handler is used.",
       control: "boolean",
@@ -731,7 +731,7 @@ const columns = [
 
   By default, this functionality is enabled. However, it will only take effect if the \`handlePageChange\` handler is not provided.
 
-- Pass the \`persistUserSortPreferences\` prop to persist the sorting state in the local storage and restore it across navigation. The local storage key can be customized with the \`localStorageKeyPrefix\` prop, similar to frozen columns.
+- Pass the \`persistSort\` prop to persist the sorting state in the local storage and restore it across navigation. The local storage key can be customized with the \`localStorageKeyPrefix\` prop, similar to frozen columns.
 `;
 
 TableWithSorting.parameters = {

--- a/stories/Components/Table.stories.jsx
+++ b/stories/Components/Table.stories.jsx
@@ -234,6 +234,12 @@ const metadata = {
       control: "function",
       table: { type: { summary: "func" } },
     },
+    persistUserSortPreferences: {
+      description:
+        "Persists the sorting state in the local storage and restores it when the Table mounts without sort params in the URL. Applicable only when the default page change handler is used.",
+      control: "boolean",
+      table: { type: { summary: "boolean" } },
+    },
     loading: {
       description: "Show loading state in Table.",
       control: "boolean",
@@ -724,6 +730,8 @@ const columns = [
   - \`page_size\`: The page size specified by the product.
 
   By default, this functionality is enabled. However, it will only take effect if the \`handlePageChange\` handler is not provided.
+
+- Pass the \`persistUserSortPreferences\` prop to persist the sorting state in the local storage and restore it across navigation. The local storage key can be customized with the \`localStorageKeyPrefix\` prop, similar to frozen columns.
 `;
 
 TableWithSorting.parameters = {

--- a/types/Table.d.ts
+++ b/types/Table.d.ts
@@ -36,7 +36,7 @@ export interface TableProps {
   onColumnHide?: (columnKey: string) => void;
   onMoreActionClick?: (actionType: string, column: any) => void;
   localStorageKeyPrefix?: string;
-  persistUserSortPreferences?: boolean;
+  persistSort?: boolean;
   enableColumnFreeze?: boolean;
   bulkSelectAllRowsProps?: {
     setBulkSelectedAllRows: () => void;

--- a/types/Table.d.ts
+++ b/types/Table.d.ts
@@ -36,6 +36,7 @@ export interface TableProps {
   onColumnHide?: (columnKey: string) => void;
   onMoreActionClick?: (actionType: string, column: any) => void;
   localStorageKeyPrefix?: string;
+  persistUserSortPreferences?: boolean;
   enableColumnFreeze?: boolean;
   bulkSelectAllRowsProps?: {
     setBulkSelectedAllRows: () => void;


### PR DESCRIPTION
- Fixes #2860 
- Ref: #https://github.com/neetozone/neeto-cal-web/issues/25557

**Description**
- `useTableSort` now writes `{ sort_by, order_by }` to localStorage (`NEETOUI-<localStorageKeyPrefix ?? pathname-hash>-SORT`, mirroring the frozen-columns key) on every sort change, including tri-state clears.
- Opt in feature

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
~- [ ] I have added tests that prove my fix is effective or that my feature works.~
- [x] I have added proper `data-testid` attributes.
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
