### PR TITLE
Add saveAndContinue variant to BlockNavigation to save the form before navigating

### DIFF
--- a/src/formik/BlockNavigation/Alert.jsx
+++ b/src/formik/BlockNavigation/Alert.jsx
@@ -8,7 +8,14 @@ import Modal from "components/Modal";
 import Typography from "components/Typography";
 import { getLocale } from "utils";
 
-const Alert = ({ isOpen = false, onClose, onSubmit, onDiscardChanges }) => {
+const Alert = ({
+  isOpen = false,
+  isSaving = false,
+  saveAndContinue = false,
+  onClose,
+  onSubmit,
+  onDiscardChanges,
+}) => {
   const { t, i18n } = useTranslation();
 
   const submitButtonRef = useRef(null);
@@ -22,15 +29,17 @@ const Alert = ({ isOpen = false, onClose, onSubmit, onDiscardChanges }) => {
   const submitButtonLabel = getLocale(
     i18n,
     t,
-    "neetoui.blockNavigation.submitButtonLabel"
+    saveAndContinue
+      ? "neetoui.blockNavigation.saveAndContinueButtonLabel"
+      : "neetoui.blockNavigation.submitButtonLabel"
   );
 
   return (
     <Modal
       {...{ isOpen, onClose }}
-      closeButton
-      closeOnEsc
-      closeOnOutsideClick
+      closeButton={!isSaving}
+      closeOnEsc={!isSaving}
+      closeOnOutsideClick={!isSaving}
       data-testid="alert-box"
       initialFocusRef={submitButtonRef}
       size="medium"
@@ -52,6 +61,7 @@ const Alert = ({ isOpen = false, onClose, onSubmit, onDiscardChanges }) => {
       <Modal.Footer className="neeto-ui-gap-2 neeto-ui-flex neeto-ui-justify-end neeto-ui-items-center">
         <Button
           data-testid="alert-cancel-button"
+          disabled={isSaving}
           label={cancelButtonLabel}
           style="danger"
           onClick={onDiscardChanges}
@@ -59,6 +69,7 @@ const Alert = ({ isOpen = false, onClose, onSubmit, onDiscardChanges }) => {
         <Button
           data-testid="alert-submit-button"
           label={submitButtonLabel}
+          loading={isSaving}
           ref={submitButtonRef}
           style="primary"
           onClick={onSubmit}

--- a/src/formik/BlockNavigation/index.jsx
+++ b/src/formik/BlockNavigation/index.jsx
@@ -1,14 +1,21 @@
 /* eslint-disable @bigbinary/neeto/file-name-and-export-name-standards */
-import React from "react";
+import React, { useState } from "react";
 
-import { useFormikContext } from "formik";
+import { setNestedObjectValues, useFormikContext } from "formik";
 import PropTypes from "prop-types";
+import { isEmpty } from "ramda";
 
 import { useNavPrompt } from "hooks";
 
 import Alert from "./Alert";
 
-const BlockNavigation = ({ isDirty = false, ...otherProps }) => {
+const BlockNavigation = ({
+  isDirty = false,
+  saveAndContinue = false,
+  ...otherProps
+}) => {
+  const [isSaving, setIsSaving] = useState(false);
+
   const formikContext = useFormikContext();
   const shouldBlock =
     isDirty || (Boolean(formikContext) && Boolean(formikContext.dirty));
@@ -23,12 +30,39 @@ const BlockNavigation = ({ isDirty = false, ...otherProps }) => {
     continueNavigation();
   };
 
+  const handleSaveAndContinue = async () => {
+    if (!formikContext) {
+      hidePrompt();
+
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      const errors = await formikContext.validateForm();
+      if (!isEmpty(errors)) {
+        formikContext.setTouched(setNestedObjectValues(errors, true), false);
+        hidePrompt();
+
+        return;
+      }
+
+      await formikContext.submitForm();
+      continueNavigation();
+    } catch {
+      hidePrompt();
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
   return (
     <Alert
+      {...{ isSaving, saveAndContinue }}
       isOpen={isBlocked}
       onClose={hidePrompt}
       onDiscardChanges={handleDiscardChanges}
-      onSubmit={hidePrompt}
+      onSubmit={saveAndContinue ? handleSaveAndContinue : hidePrompt}
       {...otherProps}
     />
   );
@@ -36,6 +70,7 @@ const BlockNavigation = ({ isDirty = false, ...otherProps }) => {
 
 BlockNavigation.propTypes = {
   isDirty: PropTypes.bool,
+  saveAndContinue: PropTypes.bool,
   message: PropTypes.string,
   title: PropTypes.string,
   submitButtonLabel: PropTypes.string,

--- a/src/formik/BlockNavigation/index.jsx
+++ b/src/formik/BlockNavigation/index.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable @bigbinary/neeto/file-name-and-export-name-standards */
 import React, { useState } from "react";
 
-import { setNestedObjectValues, useFormikContext } from "formik";
+import { useFormikContext } from "formik";
 import PropTypes from "prop-types";
 import { isEmpty } from "ramda";
 
@@ -41,7 +41,7 @@ const BlockNavigation = ({
     try {
       const errors = await formikContext.validateForm();
       if (!isEmpty(errors)) {
-        formikContext.setTouched(setNestedObjectValues(errors, true), false);
+        await formikContext.submitForm();
         hidePrompt();
 
         return;

--- a/src/formik/Form/FormWrapper.jsx
+++ b/src/formik/Form/FormWrapper.jsx
@@ -47,12 +47,15 @@ const FormWrapper = forwardRef(
             setTouched({ ...errors, ...status });
             scrollToErrorField && scrollToError(formRef, errors, status);
           } else {
-            submitForm();
+            // Awaited so a rejected submission (onSubmit returning a failed
+            // save promise) is caught below instead of surfacing as an
+            // unhandled rejection.
+            await submitForm();
           }
         } catch (error) {
           // eslint-disable-next-line no-console
           console.error(
-            "An unhandled error was caught from validateForm()",
+            "An unhandled error was caught while validating or submitting the form",
             error
           );
         }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7,6 +7,7 @@
     "blockNavigation": {
       "alertMessage": "Leaving this page will discard your unsaved data. This action cannot be undone.",
       "submitButtonLabel": "Stay on this page",
+      "saveAndContinueButtonLabel": "Save and continue",
       "cancelButtonLabel": "Discard and leave this page",
       "alertTitle": "You have unsaved changes"
     },

--- a/stories/Formik/BlockNavigation.stories.jsx
+++ b/stories/Formik/BlockNavigation.stories.jsx
@@ -16,6 +16,11 @@ are unsaved changes. It is designed to enhance the user experience by alerting
 users to the presence of pending modifications and giving them the option to
 save or discard those changes before navigating away from the current page or
 route.
+
+Pass \`saveAndContinue\` to replace the "Stay on this page" button with
+"Save and continue", which submits the surrounding Formik form and resumes the
+blocked navigation once the save settles. Return the save request's promise
+from \`onSubmit\` so the navigation waits for (and a failure cancels) the save.
 `;
 
 const metadata = {
@@ -54,7 +59,7 @@ const FormikStory = args => (
             }}
             {...args}
           >
-            <BlockNavigation />
+            <BlockNavigation saveAndContinue={args.saveAndContinue} />
             <div className="space-y-4">
               <Input required label="First name" name="firstName" />
               <Input required label="Last name" name="lastName" />
@@ -72,7 +77,7 @@ const FormikStory = args => (
 );
 
 FormikStory.storyName = "BlockNavigation";
-FormikStory.args = {};
+FormikStory.args = { saveAndContinue: false };
 
 export { FormikStory };
 

--- a/tests/formik/BlockNavigation.test.jsx
+++ b/tests/formik/BlockNavigation.test.jsx
@@ -15,7 +15,7 @@ const firstName = "Oliver",
   lastName = "Smith";
 const TestComponent = () => <div>Home page</div>;
 const mockSubmit = jest.fn();
-const TestForm = ({ isDirty }) => (
+const TestForm = ({ isDirty, saveAndContinue }) => (
   <>
     <Link to="/home">Home</Link>
     <Form
@@ -28,7 +28,7 @@ const TestForm = ({ isDirty }) => (
         onSubmit: mockSubmit,
       }}
     >
-      <BlockNavigation {...{ isDirty }} />
+      <BlockNavigation {...{ isDirty, saveAndContinue }} />
       <Input
         label="First name"
         name="firstName"
@@ -45,11 +45,11 @@ const TestForm = ({ isDirty }) => (
   </>
 );
 
-const TestBlockNavigation = ({ isDirty }) => (
+const TestBlockNavigation = ({ isDirty, saveAndContinue }) => (
   <Router>
     <Switch>
       <Route exact path="/">
-        <TestForm {...{ isDirty }} />
+        <TestForm {...{ isDirty, saveAndContinue }} />
       </Route>
       <Route component={TestComponent} path="/home" />
     </Switch>
@@ -178,5 +178,77 @@ describe("formik/BlockNavigation", () => {
     await waitFor(() => expect(submitButton).not.toBeInTheDocument());
     expect(screen.queryByText(/Home page/i)).not.toBeInTheDocument();
     expect(mockSubmit).not.toHaveBeenCalled();
+  });
+
+  describe("with saveAndContinue", () => {
+    it("should display the `Save and continue` button instead of `Stay on this page`", async () => {
+      render(<TestBlockNavigation isDirty saveAndContinue />);
+
+      await userEvent.click(screen.getByRole("link"));
+
+      expect(
+        screen.getByRole("button", { name: "Save and continue" })
+      ).toBeInTheDocument();
+
+      expect(
+        screen.queryByRole("button", { name: "Stay on this page" })
+      ).not.toBeInTheDocument();
+    });
+
+    it("should submit the form and continue the blocked navigation once the save resolves", async () => {
+      mockSubmit.mockResolvedValueOnce();
+      render(<TestBlockNavigation saveAndContinue />);
+
+      const firstNameInput = screen.getByPlaceholderText("First name");
+      await userEvent.type(firstNameInput, "Sam");
+      await userEvent.click(screen.getByRole("link"));
+
+      await userEvent.click(
+        screen.getByRole("button", { name: "Save and continue" })
+      );
+
+      await waitFor(() =>
+        expect(screen.getByText(/Home page/i)).toBeInTheDocument()
+      );
+      expect(mockSubmit).toHaveBeenCalledTimes(1);
+    });
+
+    it("should stay on the page when the save fails", async () => {
+      mockSubmit.mockRejectedValueOnce(new Error("save failed"));
+      render(<TestBlockNavigation saveAndContinue />);
+
+      const firstNameInput = screen.getByPlaceholderText("First name");
+      await userEvent.type(firstNameInput, "Sam");
+      await userEvent.click(screen.getByRole("link"));
+
+      await userEvent.click(
+        screen.getByRole("button", { name: "Save and continue" })
+      );
+
+      await waitFor(() =>
+        expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+      );
+      expect(screen.queryByText(/Home page/i)).not.toBeInTheDocument();
+      expect(mockSubmit).toHaveBeenCalledTimes(1);
+    });
+
+    it("should stay on the page without submitting when the form has validation errors", async () => {
+      render(<TestBlockNavigation saveAndContinue />);
+
+      const firstNameInput = screen.getByPlaceholderText("First name");
+      await userEvent.clear(firstNameInput);
+      await userEvent.click(screen.getByRole("link"));
+
+      await userEvent.click(
+        screen.getByRole("button", { name: "Save and continue" })
+      );
+
+      await waitFor(() =>
+        expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+      );
+      expect(screen.queryByText(/Home page/i)).not.toBeInTheDocument();
+      expect(screen.getByText(/First name is required/i)).toBeInTheDocument();
+      expect(mockSubmit).not.toHaveBeenCalled();
+    });
   });
 });

--- a/tests/formik/BlockNavigation.test.jsx
+++ b/tests/formik/BlockNavigation.test.jsx
@@ -213,7 +213,7 @@ describe("formik/BlockNavigation", () => {
       expect(mockSubmit).toHaveBeenCalledTimes(1);
     });
 
-    it("should stay on the page when the save fails", async () => {
+    it("should stay on the page with the block still active when the save fails", async () => {
       mockSubmit.mockRejectedValueOnce(new Error("save failed"));
       render(<TestBlockNavigation saveAndContinue />);
 
@@ -230,6 +230,14 @@ describe("formik/BlockNavigation", () => {
       );
       expect(screen.queryByText(/Home page/i)).not.toBeInTheDocument();
       expect(mockSubmit).toHaveBeenCalledTimes(1);
+
+      // The form is still dirty, so navigating again must be blocked.
+      expect(firstNameInput.value).toBe(`${firstName}Sam`);
+      await userEvent.click(screen.getByRole("link"));
+      expect(
+        screen.getByRole("button", { name: "Save and continue" })
+      ).toBeInTheDocument();
+      expect(screen.queryByText(/Home page/i)).not.toBeInTheDocument();
     });
 
     it("should stay on the page without submitting when the form has validation errors", async () => {

--- a/types/formik/BlockNavigation.d.ts
+++ b/types/formik/BlockNavigation.d.ts
@@ -3,6 +3,7 @@ import { AlertProps } from "../Alert";
 
 export interface BlockNavigationProps {
   isDirty?: boolean;
+  saveAndContinue?: boolean;
 }
 
 const BlockNavigation: React.FC<BlockNavigationProps & Partial<AlertProps>>;


### PR DESCRIPTION
- Fixes #2868
- Ref: https://github.com/neetozone/neeto-cal-web/issues/25816
**Description**

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added tests that prove my fix is effective or that my feature works.
~- [ ] I have added proper `data-testid` attributes.~
- [x] I have added the necessary label (`patch`/`minor`/`major` - If package publish
      is required).

**Reviewers**

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**
- Represent a component name in italics, eg: _Modal_
- Enclose a prop name in double backticks, eg: `isLoading`

Example:
- Changed: **BREAKING** `isLoading` prop of _Table_ to `loading`.
- Added: `hideOnTargetExit` prop to _Tooltip_ component.
- Deprecated: **BREAKING** `loading` prop of _Pane_, _Modal_ and _Alert_ components.
- Removed: **BREAKING** `placement` prop from _Tooltip_ (Use position instead).
--->
